### PR TITLE
Revert "fix: simplify go env setup"

### DIFF
--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -1,3 +1,5 @@
+FROM golang:1.21.5 AS go-base
+
 FROM buildpack-deps:jammy
 
 ENV NODE_TLS_REJECT_UNAUTHORIZED=0
@@ -27,7 +29,7 @@ RUN apt-get update && apt-get install -y \
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
 
 # Install Go
-COPY --from golang:1.21.5 /usr/local/go /usr/local/go
+COPY --from=go-base /usr/local/go /usr/local/go
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GOPATH="/go"
 ENV PATH="${GOPATH}/bin:${PATH}"


### PR DESCRIPTION
This reverts commit 3818d26f9c699350581abd8b4dc05583e50b0a83.